### PR TITLE
remove support for deprecated tls.VersionSSL30

### DIFF
--- a/psk.go
+++ b/psk.go
@@ -78,13 +78,11 @@ func (ka pskKeyAgreement) ProcessClientKeyExchange(config *tls.Config, cert *tls
 	}
 
 	ciphertext := ckx.Ciphertext
-	if version != tls.VersionSSL30 {
-		ciphertextLen := int(ckx.Ciphertext[0])<<8 | int(ckx.Ciphertext[1])
-		if ciphertextLen != len(ckx.Ciphertext)-2 {
-			return nil, errors.New("bad ClientKeyExchange")
-		}
-		ciphertext = ckx.Ciphertext[2:]
+	ciphertextLen := int(ckx.Ciphertext[0])<<8 | int(ckx.Ciphertext[1])
+	if ciphertextLen != len(ckx.Ciphertext)-2 {
+		return nil, errors.New("bad ClientKeyExchange")
 	}
+	ciphertext = ckx.Ciphertext[2:]
 
 	// ciphertext is actually the pskIdentity here
 	psk, err := pskConfig.GetKey(string(ciphertext))


### PR DESCRIPTION
The Go authors deprecated support for SSLv3 in go 1.13. They've decided to remove it in go 1.14, and have already merged the commit. 

See: https://golang.org/issue/32716

This PR, or something like it, should probably land before February 2020.